### PR TITLE
Add scripts to README, remove pty=True from invoke scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,43 @@ The values in example.env should work if it's just renamed to ".env", but genera
 ```bash
 invoke start
 ```
+
+### Scripts
+
+**Note: Run these scripts inside the Poetry shell. Enter `poetry shell` to activate the shell.**
+
+Install frontend dependencies and build:
+
+```bash
+invoke build-frontend
+```
+
+Install backend dependencies:
+
+```bash
+invoke build-backend
+```
+
+Run Flask app:
+
+```bash
+invoke start
+```
+
+Initialize database:
+
+```bash
+invoke init-db
+```
+
+Run `build-frontend` & `build-backend`:
+
+```bash
+invoke build-full
+```
+
+Run `build-frontend`, `build-backend` & `init-db`:
+
+```bash
+invoke build-full-init-db
+```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -18,6 +18,4 @@ You may also see any lint errors in the console.
 
 ### `npm run build`
 
-Builds frontend and copies needed files to backend `src/build/` directory. Atm not compatible with Windows!
-
-Windows workaround: `npm run react-scripts build`. When the build is ready, copy contents of `frontend/build/` directory to `src/build/`.
+Builds frontend and copies needed files to backend `src/build/` directory.

--- a/tasks.py
+++ b/tasks.py
@@ -7,26 +7,24 @@ from invoke import task
 @task
 def build_frontend(ctx):
     os.chdir('frontend')
-    ctx.run('npm ci', pty=True)
-    ctx.run('npm run build', pty=True)
+    ctx.run('npm ci')
+    ctx.run('npm run build')
     os.chdir('..')
 
 
 @task
 def build_backend(ctx):
-    ctx.run("poetry install && \
-            poetry shell",
-            pty=True)
+    ctx.run("poetry install")
 
 
 @task
 def start(ctx):
-    ctx.run("flask --app src/app.py run", pty=True)
+    ctx.run("flask --app src/app.py run")
 
 
 @task
 def init_db(ctx):
-    ctx.run("psql < schema.sql", pty=True)
+    ctx.run("psql < schema.sql")
 
 
 @task(build_frontend, build_backend)


### PR DESCRIPTION
- Added Invoke scripts to `README`
- Removed "Windows workaround" from`frontend/README` as the frontend build script should be Windows compatible already
- Removed `pty=True` from invoke scripts as Windows doesn't support it